### PR TITLE
Revert "It's not safe to unmarshal strings using unsafe (#25)"

### DIFF
--- a/types/tstring/builder.go
+++ b/types/tstring/builder.go
@@ -76,6 +76,7 @@ func (b Builder) MarshalCodeTemplate(_ *uint64) string {
 
 // UnmarshalCodeTemplate returns code template unmarshaling the data.
 func (b Builder) UnmarshalCodeTemplate(_ *uint64) string {
+	unsafe := b.tm.Import("unsafe")
 	code := `{
 	var l uint64
 `
@@ -87,9 +88,9 @@ func (b Builder) UnmarshalCodeTemplate(_ *uint64) string {
 	code += `	if l > 0 {
 `
 	if b.fieldType.Name() == "string" {
-		code += "		{{ . }} = string(b[o:o+l])\n"
+		code += fmt.Sprintf("		{{ . }} = %[1]s.String((*byte)(%[1]s.Pointer(&b[o])), l)\n", unsafe)
 	} else {
-		code += fmt.Sprintf("		{{ . }} = %[1]s(b[o:o+l])\n",
+		code += fmt.Sprintf("		{{ . }} = %[2]s(%[1]s.String((*byte)(%[1]s.Pointer(&b[o])), l))\n", unsafe,
 			b.tm.TypeName(b.msgType, b.fieldType))
 	}
 	code += `		o += l


### PR DESCRIPTION
This reverts commit 795b8940ee3927b225f8a4f40a993437e667bce4.